### PR TITLE
Stop encoding e-mail line by line

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -22,7 +22,6 @@ import logging
 import typing
 
 from collections import namedtuple
-from kitchen.text.converters import to_unicode
 import bugzilla
 
 from bodhi.server.config import config
@@ -269,7 +268,7 @@ class Bugzilla(object):
                 return
         if bug.product == 'Security Response':
             bug_entity.parent = True
-        bug_entity.title = to_unicode(bug.short_desc)
+        bug_entity.title = bug.short_desc
         if isinstance(bug.keywords, str):
             keywords = bug.keywords.split()
         else:  # python-bugzilla 0.8.0+

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -21,9 +21,6 @@ from textwrap import wrap
 import os
 import smtplib
 
-from kitchen.iterutils import iterate
-from kitchen.text.converters import to_unicode, to_bytes
-
 from bodhi.server import log
 from bodhi.server.config import config
 from bodhi.server.util import get_rpm_header, get_absolute_path
@@ -258,7 +255,7 @@ def read_template(name):
     if os.path.exists(template_path):
         try:
             with open(template_path) as template_file:
-                return to_unicode(template_file.read())
+                return template_file.read()
         except IOError as e:
             log.error("Unable to read template file: %s" % (template_path))
             log.error("IO Error[%s]: %s" % (e.errno, e.strerror))
@@ -350,17 +347,9 @@ def get_template(update, use_template='fedora_errata_template'):
             elif isinstance(oldtime, list):
                 oldtime = oldtime[0]
             info['changelog'] = u"ChangeLog:\n\n%s%s" % \
-                (to_unicode(build.get_changelog(oldtime)), line)
+                (build.get_changelog(oldtime), line)
 
-        try:
-            templates.append((info['subject'], use_template % info))
-        except UnicodeDecodeError:
-            # We can't trust the strings we get from RPM
-            log.debug("UnicodeDecodeError! Will try again after decoding")
-            for (key, value) in info.items():
-                if value:
-                    info[key] = to_unicode(value)
-            templates.append((info['subject'], use_template % info))
+        templates.append((info['subject'], use_template % info))
 
     return templates
 
@@ -412,14 +401,14 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if to_addr in config.get('exclude_mail'):
         return
 
-    subject = to_bytes(subject)
-    body_text = to_bytes(body_text)
+    subject = subject.encode('utf-8')
+    body_text = body_text.encode('utf-8')
 
-    msg = [b'From: %s' % to_bytes(from_addr), b'To: %s' % to_bytes(to_addr)]
+    msg = [b'From: %s' % from_addr.encode('utf-8'), b'To: %s' % to_addr.encode('utf-8')]
     if headers:
         for key, value in headers.items():
-            msg.append(b'%s: %s' % (to_bytes(key), to_bytes(value)))
-    msg.append(b'X-Bodhi: %s' % to_bytes(config.get('default_email_domain')))
+            msg.append(f'{key}: {value}'.encode('utf-8'))
+    msg.append(f"X-Bodhi: {config.get('default_email_domain')}".encode('utf-8'))
     msg += [b'Subject: %s' % subject, b'', body_text]
     body = b'\r\n'.join(msg)
 
@@ -466,7 +455,7 @@ def send(to, msg_type, update, sender=None, agent='bodhi'):
             headers["In-Reply-To"] = initial_message_id
 
     subject_template = u'[Fedora Update] %s[%s] %s'
-    for person in iterate(to):
+    for person in to:
         subject = subject_template % (critpath, msg_type, update.beautify_title(nvr=True))
         fields = MESSAGES[msg_type]['fields'](agent, update)
         body = MESSAGES[msg_type]['body'] % fields

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -371,7 +371,7 @@ def _send_mail(from_addr, to_addr, body):
     try:
         log.debug('Connecting to %s', smtp_server)
         smtp = smtplib.SMTP(smtp_server)
-        smtp.sendmail(from_addr, [to_addr], body)
+        smtp.sendmail(from_addr, [to_addr], body.encode('utf-8'))
     except smtplib.SMTPRecipientsRefused as e:
         log.warning('"recipient refused" for %r, %r' % (to_addr, e))
     except Exception:
@@ -388,8 +388,8 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     Args:
         from_addr (str): The address to use in the From: header.
         to_addr (str): The address to send the e-mail to.
-        subject (basestring): The subject of the e-mail.
-        body_text (basestring): The body of the e-mail to be sent.
+        subject (str): The subject of the e-mail.
+        body_text (str): The body of the e-mail to be sent.
         headers (dict or None): A mapping of header fields to values to be included in the e-mail,
             if not None.
     """
@@ -401,16 +401,13 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if to_addr in config.get('exclude_mail'):
         return
 
-    subject = subject.encode('utf-8')
-    body_text = body_text.encode('utf-8')
-
-    msg = [b'From: %s' % from_addr.encode('utf-8'), b'To: %s' % to_addr.encode('utf-8')]
+    msg = [f'From: {from_addr}', f'To: {to_addr}']
     if headers:
         for key, value in headers.items():
-            msg.append(f'{key}: {value}'.encode('utf-8'))
-    msg.append(f"X-Bodhi: {config.get('default_email_domain')}".encode('utf-8'))
-    msg += [b'Subject: %s' % subject, b'', body_text]
-    body = b'\r\n'.join(msg)
+            msg.append(f'{key}: {value}')
+    msg.append(f"X-Bodhi: {config.get('default_email_domain')}")
+    msg += [f'Subject: {subject}', '', body_text]
+    body = '\r\n'.join(msg)
 
     log.info('Sending mail to %s: %s', to_addr, subject)
     _send_mail(from_addr, to_addr, body)

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -23,7 +23,6 @@ import shelve
 import shutil
 import tempfile
 
-from kitchen.text.converters import to_bytes
 import createrepo_c as cr
 
 from bodhi.server import util
@@ -206,13 +205,13 @@ class UpdateInfoMetadata(object):
         rec.fromstr = config.get('bodhi_email')
         rec.status = update.status.value
         rec.type = update.type.value
-        rec.id = to_bytes(update.alias)
-        rec.title = to_bytes(update.title)
+        rec.id = update.alias.encode('utf-8')
+        rec.title = update.title.encode('utf-8')
         rec.severity = util.severity_updateinfo_str(update.severity.value)
-        rec.summary = to_bytes('%s %s update' % (update.get_title(),
-                                                 update.type.value))
-        rec.description = to_bytes(update.notes)
-        rec.release = to_bytes(update.release.long_name)
+        rec.summary = ('%s %s update' % (update.get_title(),
+                                         update.type.value)).encode('utf-8')
+        rec.description = update.notes.encode('utf-8')
+        rec.release = update.release.long_name.encode('utf-8')
         rec.rights = config.get('updateinfo_rights')
 
         if update.date_pushed:
@@ -229,8 +228,8 @@ class UpdateInfoMetadata(object):
             rec.updated_date = datetime.utcnow()
 
         col = cr.UpdateCollection()
-        col.name = to_bytes(update.release.long_name)
-        col.shortname = to_bytes(update.release.name)
+        col.name = update.release.long_name.encode('utf-8')
+        col.shortname = update.release.name.encode('utf-8')
 
         koji = get_session()
         for build in update.builds:
@@ -273,9 +272,9 @@ class UpdateInfoMetadata(object):
         for bug in update.bugs:
             ref = cr.UpdateReference()
             ref.type = 'bugzilla'
-            ref.id = to_bytes(bug.bug_id)
-            ref.href = to_bytes(bug.url)
-            ref.title = to_bytes(bug.title)
+            ref.id = str(bug.bug_id).encode('utf-8')
+            ref.href = bug.url.encode('utf-8')
+            ref.title = bug.title.encode('utf-8') if bug.title else ''
             rec.append_reference(ref)
 
         self.uinfo.append(rec)

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -32,7 +32,6 @@ import tempfile
 import time
 import typing
 
-from kitchen.iterutils import iterate
 from pyramid.i18n import TranslationStringFactory
 import arrow
 import bleach
@@ -399,9 +398,11 @@ def splitter(value):
     """
     if value == colander.null:
         return
+    if isinstance(value, str):
+        value = [value]
 
     items = []
-    for v in iterate(value):
+    for v in value:
         if isinstance(v, str):
             for item in v.replace(',', ' ').split():
                 items.append(item)

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -217,7 +217,7 @@ class TestSend(base.BaseTestCase):
         sendmail = SMTP.return_value.sendmail
         update = models.Update.query.all()[0]
 
-        mail.send('bowlofeggs@example.com', 'new', update, agent='bodhi')
+        mail.send(['bowlofeggs@example.com'], 'new', update, agent='bodhi')
 
         SMTP.assert_called_once_with('smtp.fp.o')
         self.assertEqual(sendmail.call_count, 1)
@@ -236,7 +236,7 @@ class TestSend(base.BaseTestCase):
         """Assert that the sent e-mail has the full NVR in the subject."""
         update = models.Update.query.all()[0]
 
-        mail.send('fake@news.com', 'comment', update, agent='bowlofeggs')
+        mail.send(['fake@news.com'], 'comment', update, agent='bowlofeggs')
 
         SMTP.assert_called_once_with('smtp.example.com')
         sendmail = SMTP.return_value.sendmail
@@ -254,7 +254,7 @@ class TestSend(base.BaseTestCase):
         """Assert that we log an exception if _send_mail catches one"""
         update = models.Update.query.all()[0]
 
-        mail.send('fake@news.com', 'comment', update, agent='bowlofeggs')
+        mail.send(['fake@news.com'], 'comment', update, agent='bowlofeggs')
 
         exception_log.assert_called_once_with('Unable to send mail')
         sendmail = SMTP.return_value.sendmail

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -38,7 +38,6 @@
       - python3-fedora
       - python3-flake8
       - python3-ipdb
-      - python3-kitchen
       - python3-koji
       - python3-librepo
       - python3-markdown

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -28,7 +28,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-feedgen \
     python3-flake8 \
     python3-jinja2 \
-    python3-kitchen \
     python3-libcomps \
     python3-librepo \
     python3-markdown \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -29,7 +29,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-feedgen \
     python3-flake8 \
     python3-jinja2 \
-    python3-kitchen \
     python3-libcomps \
     python3-librepo \
     python3-markdown \

--- a/devel/ci/Dockerfile-f30
+++ b/devel/ci/Dockerfile-f30
@@ -27,7 +27,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-flake8 \
     python3-hawkey \
     python3-jinja2 \
-    python3-kitchen \
     python3-koji \
     python3-libcomps \
     python3-librepo \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -27,7 +27,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-flake8 \
     python3-hawkey \
     python3-jinja2 \
-    python3-kitchen \
     python3-koji \
     python3-libcomps \
     python3-librepo \

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -69,6 +69,7 @@ Dependency changes
   (:issue:`2700`).
 * pillow is no longer required (:issue:`2700`).
 * six is no longer required for the client or server (:issue:`2759`).
+* kitchen is no longer required.
 
 
 Server upgrade instructions

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pyasn1-modules  # Due to an unfortunate dash in its name, installs break if pyas
 fedora_messaging
 feedgen
 jinja2
-kitchen
 markdown
 psycopg2
 py3dns  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,6 @@ ignore_missing_imports = True
 [mypy-fedora_messaging.*]
 ignore_missing_imports = True
 
-[mypy-kitchen.*]
-ignore_missing_imports = True
-
 [mypy-koji.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Instead of encoding every line of a message in send_mail(),
we only work with unicode strings and pass such body to
_send_mail(), not encoding it.

We encode the body as we pass it to SMTP.sendmail();
that is needed because otherwise it would be encoded as ASCII.

Now we only convert to bytes at the IO boundary 🧱

Disclaimer: Untested, done in the browser.